### PR TITLE
Add job arguments to Honeycomb event

### DIFF
--- a/lib/honeykiq/server_middleware.rb
+++ b/lib/honeykiq/server_middleware.rb
@@ -66,7 +66,8 @@ module Honeykiq
         'job.id': job.jid,
         'job.arguments_bytes': job.args.to_json.bytesize,
         'job.latency_sec': job.latency,
-        'job.batch_id': job['bid']
+        'job.batch_id': job['bid'],
+        'job.arguments': job.args
       }.compact
     end
 

--- a/spec/honeykiq/server_middleware_spec.rb
+++ b/spec/honeykiq/server_middleware_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Honeykiq::ServerMiddleware do
       'job.class': TestSidekiqWorker.to_s,
       'job.attempt_number': 1,
       'job.id': instance_of(String),
+      'job.arguments': instance_of(Array),
       'job.arguments_bytes': 2,
       'job.latency_sec': be_within(0.5).of(0),
       'job.status': 'finished',
@@ -62,6 +63,17 @@ RSpec.describe Honeykiq::ServerMiddleware do
       TestSidekiqWorker.perform_async
 
       expect(libhoney.events.first.data).to include(expected_event)
+    end
+
+    describe 'with job arguments' do
+      let(:test_class) { TestExtraFields }
+      let(:expected_user_event) { expected_event.merge(extra_data_item: 'foo') }
+      let(:job_arguments) { { 'debug_data' => { 'foo' => 'bar' } } }
+
+      it 'sends an event with the job arugments' do
+        TestSidekiqWorker.perform_async(job_arguments)
+        expect(libhoney.events.first.data[:'job.arguments']).to include(job_arguments)
+      end
     end
 
     describe 'adding `extra_fields`' do


### PR DESCRIPTION
Add job arguments to each Honeycomb event automatically.

See also: https://github.com/carwow/honeykiq/pull/14